### PR TITLE
Fix auxiliary functions

### DIFF
--- a/auxiliary/eus-character.l
+++ b/auxiliary/eus-character.l
@@ -1,0 +1,28 @@
+(in-package "LISP")
+
+(defun characterp (ch)
+  "Returns T if ch is a character, false otherwise."
+  (if (or (floatp ch) (derivedp ch object) (< ch 0))
+      nil
+      t))
+
+(defun char-int (ch) (assert (characterp ch)) ch)
+(defun char-not-equal (x y)
+  (assert (and (characterp x) (characterp y)))
+  (not (equal x y)))
+
+(setf (symbol-function 'char<) #'<
+      (symbol-function 'char=) #'=
+      (symbol-function 'char>) #'>
+      (symbol-function 'char/=) #'/=
+      (symbol-function 'char<=) #'<=
+      (symbol-function 'char>=) #'>=
+      (symbol-function 'char-code) #'char-int
+      (symbol-function 'char-equal) #'equal
+      (symbol-function 'char-lessp) #'<
+      (symbol-function 'char-greaterp) #'>
+      (symbol-function 'char-not-lessp) #'>=)
+
+(export '(characterp char-int char-code char-equal char-not-equal
+          char-lessp char-greaterp char-not-lessp
+          char< char= char> char/= char<= char>=))

--- a/auxiliary/eus-predicates.l
+++ b/auxiliary/eus-predicates.l
@@ -1,25 +1,8 @@
 (in-package "LISP")
 
-(defun char< (ch &rest chars)
-  "Returns T if its arguments are in increasing alphabetic order."
-  (OOchar< ch chars))
 
-(defmacro OOchar (ch chars)
-  `(< ch ,@chars))
-
-(defun char-equal (character &rest more-characters)
-  "Returns T if all of its arguments are the same character.
-   Case is ignored."
-  (do ((clist more-characters (cdr clist)))
-      ((atom clist) T)
-    (unless (= (car clist) character)
-      (return nil))))
-
-(defun characterp (ch)
-  "Returns T if ch is a character, false otherwise."
-  (if (or (floatp ch) (derivedp ch object) (< ch 0))
-      nil
-      t))
+(defmacro complement (fn)
+  `(function (lambda (&rest args) (not (apply ,fn args)))))
 
 ;;; EQUALP -- public.
 ;;
@@ -94,4 +77,4 @@
 		    (return-from equalp nil))))))
 	(t nil)))
 
-(export '(char-equal equalp char< characterp))
+(export '(complement equalp))

--- a/auxiliary/eus-sequences.l
+++ b/auxiliary/eus-sequences.l
@@ -5,70 +5,67 @@
 (in-package :lisp)
 
 
-(defun substitute (newitem olditem seq &key (start 0)
-                                         (end (length seq))
-                                         (test #'eq)
-                                         (test-not nil)
-                                         (count 1000000)
-                                         (key #'identity)
-                                         (from-end nil))
-  (let ((count (or (and count (< count 0) 0) count 1000000)))
-    (if from-end
-        (reverse (system::raw-substitute newitem olditem (reverse seq) test test-not key nil nil start end count))
-        (system::raw-substitute newitem olditem seq test test-not key nil nil start end count))))
+;; TODO: implement from-end in sequence.c
+(defmacro defsubstitute (name fn arg-lst
+			 newitem olditem seq test testnot key iftest ifnottest start end count)  
+  `(defun ,name ,arg-lst
+     (let ((count (or (and count (< count 0) 0) count 1000000))
+	   len)
+       (unless end (setq len (length seq) end len))
+       (if from-end
+	   (let ((len (or len (length seq))))
+	     (reverse (,fn ,newitem ,olditem (reverse ,seq) ,test ,testnot ,key ,iftest ,ifnottest (- len ,end) (- len ,start) ,count)))
+	   (,fn ,newitem ,olditem ,seq ,test ,testnot ,key ,iftest ,ifnottest ,start ,end ,count)))))
 
-(defun substitute-if (newitem pred seq &key (start 0)
-                                         (end (length seq))
-                                         (count 1000000)
-                                         (key #'identity)
-                                         (from-end nil))
-  (let ((count (or (and count (< count 0) 0) count 1000000)))
-    (if from-end
-        (reverse (system::raw-substitute newitem nil (reverse seq) nil nil key pred nil start end count))
-        (system::raw-substitute newitem nil seq nil nil key pred nil start end count))))
+(defsubstitute substitute system::raw-substitute
+  (newitem olditem seq 
+	   &key (start 0) (end nil)
+	   (test #'eq) (test-not nil)
+	   (count 1000000)
+	   (key #'identity)
+	   (from-end nil))
+  newitem olditem seq test test-not key nil nil start end count)
 
-(defun substitute-if-not (newitem pred seq &key (start 0)
-                                             (end (length seq))
-                                             (count 1000000)
-                                             (key #'identity)
-                                             (from-end nil))
-  (let ((count (or (and count (< count 0) 0) count 1000000)))
-    (if from-end
-        (reverse (system::raw-substitute newitem nil (reverse seq) nil nil key nil pred start end count))
-        (system::raw-substitute newitem nil seq nil nil key nil pred start end count))))
+(defsubstitute substitute-if system::raw-substitute
+  (newitem pred seq
+	   &key (start 0) (end nil)
+	   (count 1000000)
+	   (key #'identity)
+	   (from-end nil))
+  newitem nil seq nil nil key pred nil start end count)
 
+(defsubstitute substitute-if-not system::raw-substitute
+  (newitem pred seq
+	   &key (start 0) (end nil)
+	   (count 1000000)
+	   (key #'identity)
+	   (from-end nil))
+  newitem nil seq nil nil key nil pred start end count)
 
-(defun nsubstitute (newitem olditem seq &key (start 0)
-                                          (end (length seq))
-                                          (test #'eq)
-                                          (test-not nil)
-                                          (count 1000000)
-                                          (key #'identity)
-                                          (from-end nil))
-  (let ((count (or (and count (< count 0) 0) count 1000000)))
-    (if from-end
-        (reverse (system::raw-nsubstitute newitem olditem (reverse seq) test test-not key nil nil start end count))
-        (system::raw-nsubstitute newitem olditem seq test test-not key nil nil start end count))))
+(defsubstitute nsubstitute system::raw-nsubstitute
+  (newitem olditem seq
+	   &key (start 0) (end nil)
+	   (test #'eq) (test-not nil)
+	   (count 1000000)
+	   (key #'identity)
+	   (from-end nil))
+  newitem olditem seq test test-not key nil nil start end count)
 
-(defun nsubstitute-if (newitem pred seq &key (start 0)
-                                          (end (length seq))
-                                          (nil)
-                                          (key #'identity)
-                                          (from-end nil))
-  (let ((count (or (and count (< count 0) 0) count 1000000)))
-    (if from-end
-        (reverse (system::raw-nsubstitute newitem nil (reverse seq) nil nil key pred nil start end count))
-        (system::raw-nsubstitute newitem nil seq nil nil key pred nil start end count))))
+(defsubstitute nsubstitute-if system::raw-nsubstitute
+  (newitem pred seq
+	   &key (start 0) (end nil)
+	   (key #'identity)
+	   (count 1000000)
+	   (from-end nil))
+  newitem nil seq nil nil key pred nil start end count)
 
-(defun nsubstitute-if-not (newitem pred seq &key (start 0)
-                                              (end (length seq))
-                                              (count 1000000)
-                                              (key #'identity)
-                                              (from-end nil))
-  (let ((count (or (and count (< count 0) 0) count 1000000)))
-    (if from-end
-        (reverse (system::raw-nsubstitute newitem nil (reverse seq) nil nil key nil pred start end count))
-        (system::raw-nsubstitute newitem nil seq nil nil key nil pred start end count))))
+(defsubstitute nsubstitute-if-not system::raw-nsubstitute
+  (newitem pred seq
+	   &key (start 0) (end nil)
+	   (count 1000000)
+	   (key #'identity)
+	   (from-end nil))
+  newitem nil seq nil nil key nil pred start end count)
 
 ;; ;; Shadows replace function
 ;; ;; - replace should default nil to entire string

--- a/auxiliary/eus-sequences.l
+++ b/auxiliary/eus-sequences.l
@@ -100,12 +100,26 @@
 
 ;; Add mismatch function
 
+(defmacro mismatch-core (from-end)
+  `(when (if test-not
+	     (funcall test-not
+		      (funcall key (elt seq1 index1))
+		      (funcall key (elt seq2 index2)))
+	     (not (funcall test
+			   (funcall key (elt seq1 index1))
+			   (funcall key (elt seq2 index2)))))
+     (return-from mismatch ,(if from-end
+				'(1+ index1)
+				'index1))))
+
 (defun mismatch (seq1 seq2 &key (from-end nil)
                                 (test #'eql)
+                                (test-not nil)
                                 (start1 0)
                                 (start2 0)
                                 (end1 nil)
-                                (end2 nil))
+                                (end2 nil)
+                                (key #'identity))
   "The specified subsequences of Sequence1 and Sequence2 are compared
    element-wise.  If they are of equal length and match in every element, the
    result is NIL.  Otherwise, the result is a non-negative integer, the index
@@ -115,21 +129,23 @@
    :From-End keyword argument is given, then one plus the index of the
    rightmost position in which the sequences differ is returned."
   (let ((end1 (or end1 (length seq1)))
-        (end2 (or end2 (length seq2)))
-        (seq1 (or (and from-end (reverse seq1)) seq1))
-        (seq2 (or (and from-end (reverse seq2)) seq2)))
-    (progn
-      (loop
-         for index1 from start1 to (- end1 1)
-         for index2 from start2 to (- end2 1)
-         do
-           (when (not (funcall test (elt seq1 index1) (elt seq2 index2)))
-             (return-from mismatch index1))
-      )
-      (if (> (- end1 start1) (- end2 start2))
-          end1
-          nil))))
-
+        (end2 (or end2 (length seq2))))
+    (if (or (zerop end1) (zerop end2)) (return-from mismatch 0))
+    (if from-end
+	(loop
+	   for index1 from (- end1 1) downto start1
+	   for index2 from (- end2 1) downto start2
+	 do
+	     (mismatch-core t))
+	(loop
+	   for index1 from start1 below end1
+	   for index2 from start2 below end2
+	 do
+	     (mismatch-core nil)))
+    (cond
+      ((> (- end1 start1) (- end2 start2)) end2)
+      ((< (- end1 start1) (- end2 start2)) end1)
+      (t nil))))
 
 ;; ;; Auxiliary function to shadow peek-char
 ;; (defun OOpeek-char (&optional (stream *standard-input*)

--- a/auxiliary/search-aux.lsp
+++ b/auxiliary/search-aux.lsp
@@ -10,20 +10,22 @@
       a b a b b a b a a b a a a b b a a b a a a a b b a b a b a a a b a b
       b a b a a b b b b b a a a a a b a b b b b b a b a b b a b a b))
 
-;; (defparameter *pattern-sublists*
-;;   (remove-duplicates
-;;    (let* ((s *searched-list*) (len (length s)))
-;;      (loop for x from 0 to 8 nconc
-;;            (loop for y from 0 to (- len x)
-;;                  collect (subseq s y (+ y x)))))
-;;    :test #'equal))
+(defparameter *pattern-sublists*
+  (remove-duplicates
+   (let* ((s *searched-list*) (len (length s)))
+     (loop for x from 0 to 8 nconc
+           (loop for y from 0 to (- len x)
+	      collect (if (= y len)
+			  nil
+			  (subseq s y (+ y x))))))
+   :test #'equal))
 
 (defparameter *searched-vector*
   (make-array (length *searched-list*)
               :initial-contents *searched-list*))
 
-;; (defparameter *pattern-subvectors*
-;;   (mapcar #'(lambda (x) (apply #'vector x)) *pattern-sublists*))
+(defparameter *pattern-subvectors*
+  (mapcar #'(lambda (x) (apply #'vector x)) *pattern-sublists*))
 
 (defparameter *searched-bitvector*
   #*1101111111010111010111000010010000001011010010001100100001101010001011010011111000001011111010110101)
@@ -34,7 +36,7 @@
      (loop for x from 0 to 8 nconc
            (loop for y from 0 to (- len x)
                  collect (subseq s y (+ y x)))))
-   :test #'equalp))
+   :test #'equal))
 
 (defparameter *searched-string*
   "1101111111010111010111000010010000001011010010001100100001101010001011010011111000001011111010110101")
@@ -45,9 +47,9 @@
      (loop for x from 0 to 8 nconc
            (loop for y from 0 to (- len x)
                  collect (subseq s y (+ y x)))))
-   :test #'equalp))
+   :test #'equal))
 
-(defun subseq-equalp (seq1 seq2 start1 start2 len &key (test #'equalp))
+(defun subseq-equalp (seq1 seq2 start1 start2 len &key (test #'equal))
   (assert
    (and
     (>= start1 0)
@@ -68,7 +70,7 @@
 
 (defun search-check (pattern searched pos
                              &key (start1 0) (end1 nil) (start2 0) (end2 nil)
-                             key from-end (test #'equalp))
+                             key from-end (test #'equal))
   (unless end1 (setq end1 (length pattern)))
   (unless end2 (setq end2 (length searched)))
   (assert (<= start1 end1))

--- a/eus-test.l
+++ b/eus-test.l
@@ -4,6 +4,7 @@
 ;; LOAD CL-compatibility libraries
 (load "auxiliary/eus-multiple-values.l")
 (load "auxiliary/eus-loop.l")
+(load "auxiliary/eus-character.l")
 (load "auxiliary/eus-predicates.l")
 (load "auxiliary/eus-sequences.l")
 

--- a/sequences/nsubstitute-if-not.lsp
+++ b/sequences/nsubstitute-if-not.lsp
@@ -13,9 +13,9 @@
   (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x) x)
   (b b b c))
 
-;; (deftest nsubstitute-if-not-list.3
-;;   (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :count nil))
-;;   (b b b c))
+(deftest nsubstitute-if-not-list.3
+  (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :count nil))
+  (b b b c))
 
 (deftest nsubstitute-if-not-list.4
   (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :count 2))
@@ -41,9 +41,9 @@
   (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :from-end t))
   (b b b c))
 
-;; (deftest nsubstitute-if-not-list.10
-;;   (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :from-end t :count nil))
-;;   (b b b c))
+(deftest nsubstitute-if-not-list.10
+  (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :from-end t :count nil))
+  (b b b c))
 
 (deftest nsubstitute-if-not-list.11
   (let ((x (copy-seq '(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :count 2 :from-end t))
@@ -117,9 +117,9 @@
   (let ((x (copy-seq #(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x))
   #(b b b c))
 
-;; (deftest nsubstitute-if-not-vector.3
-;;   (let ((x (copy-seq #(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :count nil) x)
-;;   #(b b b c))
+(deftest nsubstitute-if-not-vector.3
+  (let ((x (copy-seq #(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :count nil) x)
+  #(b b b c))
 
 (deftest nsubstitute-if-not-vector.4
   (let ((x (copy-seq #(a b a c)))) (nsubstitute-if-not 'b (is-not-eql-p 'a) x :count 2))
@@ -166,17 +166,16 @@
   #(a b a c))
 
 (deftest nsubstitute-if-not-vector.15
-;;   (loop for i from 0 to 9 always
-;;         (loop for j from i to 10 always
-;;               (let* ((orig #(a a a a a a a a a a))
-;;                      (x (copy-seq orig))
-;;                      (y (nsubstitute-if-not 'x (is-not-eql-p 'a) x :start i :end j)))
-;;                 (equalp y (concatenate 'simple-vector
-;;                                        (make-array i :initial-element 'a)
-;;                                        (make-array (- j i) :initial-element 'x)
-;;                                        (make-array (- 10 j) :initial-element 'a))))))
-    ;;   t)
-    (error "there is no explicit simple-vector type"))
+  (loop for i from 0 to 9 always
+        (loop for j from i to 10 always
+              (let* ((orig #(a a a a a a a a a a))
+                     (x (copy-seq orig))
+                     (y (nsubstitute-if-not 'x (is-not-eql-p 'a) x :start i :end j)))
+                (equalp y (concatenate 'simple-vector
+                                       (make-array i :initial-element 'a)
+                                       (make-array (- j i) :initial-element 'x)
+                                       (make-array (- 10 j) :initial-element 'a))))))
+      t)
 
 (deftest nsubstitute-if-not-vector.16
   (loop for i from 0 to 9 always
@@ -269,9 +268,9 @@
   (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x))
   "bbbc")
 
-;; (deftest nsubstitute-if-not-string.3
-;;   (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x :count nil))
-;;   "bbbc")
+(deftest nsubstitute-if-not-string.3
+  (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x :count nil))
+  "bbbc")
 
 (deftest nsubstitute-if-not-string.4
   (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x :count 2))
@@ -297,9 +296,9 @@
   (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x :from-end t))
   "bbbc")
 
-;; (deftest nsubstitute-if-not-string.10
-;;   (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x :from-end t :count nil))
-;;   "bbbc")
+(deftest nsubstitute-if-not-string.10
+  (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x :from-end t :count nil))
+  "bbbc")
 
 (deftest nsubstitute-if-not-string.11
   (let ((x (copy-seq "abac"))) (nsubstitute-if-not #\b (is-not-eql-p #\a) x :count 2 :from-end t))
@@ -536,19 +535,19 @@
     result)
   #*010101)
 
-;; (deftest nsubstitute-if-not-bit-vector.18
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (nsubstitute-if-not 1 (is-not-eql-p 0) x :count nil)))
-;;     result)
-;;   #*111111)
+(deftest nsubstitute-if-not-bit-vector.18
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (nsubstitute-if-not 1 (is-not-eql-p 0) x :count nil)))
+    result)
+  #*111111)
 
-;; (deftest nsubstitute-if-not-bit-vector.19
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (nsubstitute-if-not 1 (is-not-eql-p 0) x :count nil :from-end t)))
-;;     result)
-;;   #*111111)
+(deftest nsubstitute-if-not-bit-vector.19
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (nsubstitute-if-not 1 (is-not-eql-p 0) x :count nil :from-end t)))
+    result)
+  #*111111)
 
 (deftest nsubstitute-if-not-bit-vector.20
   (loop for i from 0 to 9 always

--- a/sequences/substitute-if-not.lsp
+++ b/sequences/substitute-if-not.lsp
@@ -14,10 +14,10 @@
   (b b b c)
   (a b a c))
 
-;; (deftest substitute-if-not-list.3
-;;   (let ((x '(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :count nil) x))
-;;   (b b b c)
-;;   (a b a c))
+(deftest substitute-if-not-list.3
+  (let ((x '(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :count nil) x))
+  (b b b c)
+  (a b a c))
 
 (deftest substitute-if-not-list.4
   (let ((x '(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :count 2) x))
@@ -134,10 +134,10 @@
   #(b b b c)
   #(a b a c))
 
-;; (deftest substitute-if-not-vector.3
-;;   (let ((x #(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :count nil) x))
-;;   #(b b b c)
-;;   #(a b a c))
+(deftest substitute-if-not-vector.3
+  (let ((x #(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :count nil) x))
+  #(b b b c)
+  #(a b a c))
 
 (deftest substitute-if-not-vector.4
   (let ((x #(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :count 2) x))
@@ -168,10 +168,10 @@
   #(b b b c)
   #(a b a c))
 
-;; (deftest substitute-if-not-vector.10
-;;   (let ((x #(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :from-end t :count nil) x))
-;;   #(b b b c)
-;;   #(a b a c))
+(deftest substitute-if-not-vector.10
+  (let ((x #(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :from-end t :count nil) x))
+  #(b b b c)
+  #(a b a c))
 
 (deftest substitute-if-not-vector.11
   (let ((x #(a b a c))) (values (substitute-if-not 'b (is-not-eql-p 'a) x :count 2 :from-end t) x))
@@ -309,10 +309,10 @@
   "bbbc"
   "abac")
 
-;; (deftest substitute-if-not-string.3
-;;   (let ((x "abac")) (values (substitute-if-not #\b (is-not-eql-p #\a) x :count nil) x))
-;;   "bbbc"
-;;   "abac")
+(deftest substitute-if-not-string.3
+  (let ((x "abac")) (values (substitute-if-not #\b (is-not-eql-p #\a) x :count nil) x))
+  "bbbc"
+  "abac")
 
 (deftest substitute-if-not-string.4
   (let ((x "abac")) (values (substitute-if-not #\b (is-not-eql-p #\a) x :count 2) x))
@@ -343,10 +343,10 @@
   "bbbc"
   "abac")
 
-;; (deftest substitute-if-not-string.10
-;;   (let ((x "abac")) (values (substitute-if-not #\b (is-not-eql-p #\a) x :from-end t :count nil) x))
-;;   "bbbc"
-;;   "abac")
+(deftest substitute-if-not-string.10
+  (let ((x "abac")) (values (substitute-if-not #\b (is-not-eql-p #\a) x :from-end t :count nil) x))
+  "bbbc"
+  "abac")
 
 (deftest substitute-if-not-string.11
   (let ((x "abac")) (values (substitute-if-not #\b (is-not-eql-p #\a) x :count 2 :from-end t) x))

--- a/sequences/substitute-if.lsp
+++ b/sequences/substitute-if.lsp
@@ -10,53 +10,48 @@
   nil nil)
 
 (deftest substitute-if-list.2
-  ;; (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x) x))
-  ;; (b b b c)
-    ;; (a b a c))
-    (error "fatal error"))
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x) x))
+  (b b b c)
+    (a b a c))
 
 (deftest substitute-if-list.3
-  ;; (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count nil) x))
-  ;; (b b b c)
-    ;; (a b a c))
-    (error "fatal error"))
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count nil) x))
+  (b b b c)
+    (a b a c))
 
 (deftest substitute-if-list.4
-  ;; (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 2) x))
-  ;; (b b b c)
-  ;; (a b a c))
-    (error "fatal error"))
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 2) x))
+  (b b b c)
+  (a b a c))
 
 (deftest substitute-if-list.5
-  ;; (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 1) x))
-  ;; (b b a c)
-    ;; (a b a c))
-    (error "fatal error"))
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 1) x))
+  (b b a c)
+    (a b a c))
 
-;; (deftest substitute-if-list.6
-;;   (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 0) x))
-;;   (a b a c)
-;;   (a b a c))
+(deftest substitute-if-list.6
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 0) x))
+  (a b a c)
+  (a b a c))
 
-;; (deftest substitute-if-list.7
-;;   (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count -1) x))
-;;   (a b a c)
-;;   (a b a c))
+(deftest substitute-if-list.7
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count -1) x))
+  (a b a c)
+  (a b a c))
 
 (deftest substitute-if-list.8
-  ;; (let ((x '())) (values (substitute-if 'b (is-eql-p 'a) x :from-end t) x))
-    ;; nil nil)
-    (error "fatal error"))
+  (let ((x '())) (values (substitute-if 'b (is-eql-p 'a) x :from-end t) x))
+    nil nil)
 
-;; (deftest substitute-if-list.9
-;;   (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :from-end t) x))
-;;   (b b b c)
-;;   (a b a c))
+(deftest substitute-if-list.9
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :from-end t) x))
+  (b b b c)
+  (a b a c))
 
-;; (deftest substitute-if-list.10
-;;   (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :from-end t :count nil) x))
-;;   (b b b c)
-;;   (a b a c))
+(deftest substitute-if-list.10
+  (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :from-end t :count nil) x))
+  (b b b c)
+  (a b a c))
 
 (deftest substitute-if-list.11
   (let ((x '(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 2 :from-end t) x))
@@ -140,10 +135,10 @@
   #(b b b c)
   #(a b a c))
 
-;; (deftest substitute-if-vector.3
-;;   (let ((x #(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count nil) x))
-;;   #(b b b c)
-;;   #(a b a c))
+(deftest substitute-if-vector.3
+  (let ((x #(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count nil) x))
+  #(b b b c)
+  #(a b a c))
 
 (deftest substitute-if-vector.4
   (let ((x #(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 2) x))
@@ -174,10 +169,10 @@
   #(b b b c)
   #(a b a c))
 
-;; (deftest substitute-if-vector.10
-;;   (let ((x #(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :from-end t :count nil) x))
-;;   #(b b b c)
-;;   #(a b a c))
+(deftest substitute-if-vector.10
+  (let ((x #(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :from-end t :count nil) x))
+  #(b b b c)
+  #(a b a c))
 
 (deftest substitute-if-vector.11
   (let ((x #(a b a c))) (values (substitute-if 'b (is-eql-p 'a) x :count 2 :from-end t) x))
@@ -328,10 +323,10 @@
   "bbbc"
   "abac")
 
-;; (deftest substitute-if-string.3
-;;   (let ((x "abac")) (values (substitute-if #\b (is-eql-p #\a) x :count nil) x))
-;;   "bbbc"
-;;   "abac")
+(deftest substitute-if-string.3
+  (let ((x "abac")) (values (substitute-if #\b (is-eql-p #\a) x :count nil) x))
+  "bbbc"
+  "abac")
 
 (deftest substitute-if-string.4
   (let ((x "abac")) (values (substitute-if #\b (is-eql-p #\a) x :count 2) x))
@@ -619,21 +614,21 @@
          result))
   #*010101)
 
-;; (deftest substitute-if-bit-vector.18
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (substitute-if 1 #'zerop x :count nil)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*111111)
+(deftest substitute-if-bit-vector.18
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute-if 1 #'zerop x :count nil)))
+    (and (equalp orig x)
+         result))
+  #*111111)
 
-;; (deftest substitute-if-bit-vector.19
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (substitute-if 1 #'zerop x :count nil :from-end t)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*111111)
+(deftest substitute-if-bit-vector.19
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute-if 1 #'zerop x :count nil :from-end t)))
+    (and (equalp orig x)
+         result))
+  #*111111)
 
 (deftest substitute-if-bit-vector.20
   (loop for i from 0 to 9 always

--- a/sequences/substitute.lsp
+++ b/sequences/substitute.lsp
@@ -714,304 +714,286 @@
 ;;; Tests on bit-vectors
 
 (deftest substitute-bit-vector.1
-  ;; (let* ((orig #*)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 0 1 x)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*)
-    (error "problem with #*"))
+  (let* ((orig #*)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x)))
+    (and (equalp orig x)
+         result))
+    #*)
 
 (deftest substitute-bit-vector.2
-  ;; (let* ((orig #*)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-  ;; #*)
-    (error "problem with #*"))
+  (let* ((orig #*)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x)))
+    (and (equalp orig x)
+         result))
+  #*)
 
 (deftest substitute-bit-vector.3
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 0 1 x)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*000000)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x)))
+    (and (equalp orig x)
+         result))
+    #*000000)
 
 (deftest substitute-bit-vector.4
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*111111)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x)))
+    (and (equalp orig x)
+         result))
+    #*111111)
 
 (deftest substitute-bit-vector.5
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x :start 1)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*011111)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :start 1)))
+    (and (equalp orig x)
+         result))
+    #*011111)
 
 (deftest substitute-bit-vector.6
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 0 1 x :start 2 :end nil)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*010000)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x :start 2 :end nil)))
+    (and (equalp orig x)
+         result))
+    #*010000)
 
 (deftest substitute-bit-vector.7
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x :end 4)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*111101)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :end 4)))
+    (and (equalp orig x)
+         result))
+    #*111101)
 
 (deftest substitute-bit-vector.8
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 0 1 x :end nil)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*000000)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x :end nil)))
+    (and (equalp orig x)
+         result))
+    #*000000)
 
 (deftest substitute-bit-vector.9
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 0 1 x :end 3)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*000101)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x :end 3)))
+    (and (equalp orig x)
+         result))
+    #*000101)
 
 (deftest substitute-bit-vector.10
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 0 1 x :start 2 :end 4)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*010001)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x :start 2 :end 4)))
+    (and (equalp orig x)
+         result))
+    #*010001)
 
 (deftest substitute-bit-vector.11
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x :start 2 :end 4)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*011101)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :start 2 :end 4)))
+    (and (equalp orig x)
+         result))
+    #*011101)
 
 (deftest substitute-bit-vector.12
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x :count 1)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*110101)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count 1)))
+    (and (equalp orig x)
+         result))
+    #*110101)
 
 (deftest substitute-bit-vector.13
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x :count 0)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*010101)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count 0)))
+    (and (equalp orig x)
+         result))
+    #*010101)
 
 (deftest substitute-bit-vector.14
-  ;; (let* ((orig #*010101)
-  ;;        (x (copy-seq orig))
-  ;;        (result (substitute 1 0 x :count -1)))
-  ;;   (and (equalp orig x)
-  ;;        result))
-    ;; #*010101)
-    (error "problem with letting #*X"))
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count -1)))
+    (and (equalp orig x)
+         result))
+    #*010101)
 
-;; (deftest substitute-bit-vector.15
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (substitute 1 0 x :count 1 :from-end t)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*010111)
+(deftest substitute-bit-vector.15
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count 1 :from-end t)))
+    (and (equalp orig x)
+         result))
+  #*010111)
 
-;; (deftest substitute-bit-vector.16
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (substitute 1 0 x :count 0 :from-end t)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*010101)
+(deftest substitute-bit-vector.16
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count 0 :from-end t)))
+    (and (equalp orig x)
+         result))
+  #*010101)
 
-;; (deftest substitute-bit-vector.17
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (substitute 1 0 x :count -1 :from-end t)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*010101)
+(deftest substitute-bit-vector.17
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count -1 :from-end t)))
+    (and (equalp orig x)
+         result))
+  #*010101)
 
-;; (deftest substitute-bit-vector.18
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (substitute 1 0 x :count nil)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*111111)
+(deftest substitute-bit-vector.18
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count nil)))
+    (and (equalp orig x)
+         result))
+  #*111111)
 
-;; (deftest substitute-bit-vector.19
-;;   (let* ((orig #*010101)
-;;          (x (copy-seq orig))
-;;          (result (substitute 1 0 x :count nil :from-end t)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*111111)
+(deftest substitute-bit-vector.19
+  (let* ((orig #*010101)
+         (x (copy-seq orig))
+         (result (substitute 1 0 x :count nil :from-end t)))
+    (and (equalp orig x)
+         result))
+  #*111111)
 
-;; (deftest substitute-bit-vector.20
-;;   (loop for i from 0 to 9 always
-;;         (loop for j from i to 10 always
-;;               (loop for c from 0 to (- j i) always
-;;                     (let* ((orig #*0000000000)
-;;                            (x (copy-seq orig))
-;;                            (y (substitute 1 0 x :start i :end j :count c)))
-;;                       (and (equalp orig x)
-;;                            (equalp y (concatenate
-;;                                       'simple-bit-vector
-;;                                       (make-list i :initial-element 0)
-;;                                       (make-list c :initial-element 1)
-;;                                       (make-list (- 10 (+ i c)) :initial-element 0))))))))
-;;   t)
+(deftest substitute-bit-vector.20
+  (loop for i from 0 to 9 always
+        (loop for j from i to 10 always
+              (loop for c from 0 to (- j i) always
+                    (let* ((orig #*0000000000)
+                           (x (copy-seq orig))
+                           (y (substitute 1 0 x :start i :end j :count c)))
+                      (and (equalp orig x)
+                           (equalp y (concatenate
+                                      'simple-bit-vector
+                                      (make-list i :initial-element 0)
+                                      (make-list c :initial-element 1)
+                                      (make-list (- 10 (+ i c)) :initial-element 0))))))))
+  t)
 
-;; (deftest substitute-bit-vector.21
-;;   (loop for i from 0 to 9 always
-;;         (loop for j from i to 10 always
-;;               (loop for c from 0 to (- j i) always
-;;                     (let* ((orig #*1111111111)
-;;                            (x (copy-seq orig))
-;;                            (y (substitute 0 1 x :start i :end j :count c :from-end t)))
-;;                       (and (equalp orig x)
-;;                            (equalp y (concatenate
-;;                                       'simple-bit-vector
-;;                                       (make-list (- j c) :initial-element 1)
-;;                                       (make-list c :initial-element 0)
-;;                                       (make-list (- 10 j) :initial-element 1))))))))
-;;   t)
+(deftest substitute-bit-vector.21
+  (loop for i from 0 to 9 always
+        (loop for j from i to 10 always
+              (loop for c from 0 to (- j i) always
+                    (let* ((orig #*1111111111)
+                           (x (copy-seq orig))
+                           (y (substitute 0 1 x :start i :end j :count c :from-end t)))
+                      (and (equalp orig x)
+                           (equalp y (concatenate
+                                      'simple-bit-vector
+                                      (make-list (- j c) :initial-element 1)
+                                      (make-list c :initial-element 0)
+                                      (make-list (- 10 j) :initial-element 1))))))))
+  t)
 
-;; (deftest substitute-bit-vector.22
-;;   (let* ((orig #*0101010101)
-;;          (x (copy-seq orig))
-;;          (c 0)
-;;          (result (substitute 1 0 x :test #'(lambda (a b) (incf c) (and (<= 2 c 5) (= a b))))))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*0111110101)
+(deftest substitute-bit-vector.22
+  (let* ((orig #*0101010101)
+         (x (copy-seq orig))
+         (c 0)
+         (result (substitute 1 0 x :test #'(lambda (a b) (incf c) (and (<= 2 c 5) (= a b))))))
+    (and (equalp orig x)
+         result))
+  #*0111110101)
 
-;; (deftest substitute-bit-vector.23
-;;   (let* ((orig #*0101010101)
-;;          (x (copy-seq orig))
-;;          (c 0)
-;;          (result (substitute 1 0 x :test-not #'(lambda (a b) (incf c)
-;;                                                  (not (and (<= 2 c 5) (= a b)))))))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*0111110101)
+(deftest substitute-bit-vector.23
+  (let* ((orig #*0101010101)
+         (x (copy-seq orig))
+         (c 0)
+         (result (substitute 1 0 x :test-not #'(lambda (a b) (incf c)
+                                                 (not (and (<= 2 c 5) (= a b)))))))
+    (and (equalp orig x)
+         result))
+  #*0111110101)
 
-;; (deftest substitute-bit-vector.24
-;;   (let* ((orig #*0101010101)
-;;          (x (copy-seq orig))
-;;          (c 0)
-;;          (result (substitute 1 0 x :test #'(lambda (a b) (incf c) (and (<= 2 c 5) (= a b)))
-;;                              :from-end t)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*0101011111)
+(deftest substitute-bit-vector.24
+  (let* ((orig #*0101010101)
+         (x (copy-seq orig))
+         (c 0)
+         (result (substitute 1 0 x :test #'(lambda (a b) (incf c) (and (<= 2 c 5) (= a b)))
+                             :from-end t)))
+    (and (equalp orig x)
+         result))
+  #*0101011111)
 
-;; (deftest substitute-bit-vector.25
-;;   (let* ((orig #*0101010101)
-;;          (x (copy-seq orig))
-;;          (c 0)
-;;          (result (substitute 1 0 x :test-not #'(lambda (a b) (incf c)
-;;                                                  (not (and (<= 2 c 5) (= a b))))
-;;                              :from-end t)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*0101011111)
+(deftest substitute-bit-vector.25
+  (let* ((orig #*0101010101)
+         (x (copy-seq orig))
+         (c 0)
+         (result (substitute 1 0 x :test-not #'(lambda (a b) (incf c)
+                                                 (not (and (<= 2 c 5) (= a b))))
+                             :from-end t)))
+    (and (equalp orig x)
+         result))
+  #*0101011111)
 
-;; (deftest substitute-bit-vector.26
-;;   (let* ((orig #*00111001011010110)
-;;          (x (copy-seq orig))
-;;          (result (substitute 1 1 x :key #'1+)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*11111111111111111)
+(deftest substitute-bit-vector.26
+  (let* ((orig #*00111001011010110)
+         (x (copy-seq orig))
+         (result (substitute 1 1 x :key #'1+)))
+    (and (equalp orig x)
+         result))
+  #*11111111111111111)
 
-;; (deftest substitute-bit-vector.27
-;;   (let* ((orig #*00111001011010110)
-;;          (x (copy-seq orig))
-;;          (result (substitute 1 1 x :key #'1+ :start 1 :end 10)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*01111111111010110)
+(deftest substitute-bit-vector.27
+  (let* ((orig #*00111001011010110)
+         (x (copy-seq orig))
+         (result (substitute 1 1 x :key #'1+ :start 1 :end 10)))
+    (and (equalp orig x)
+         result))
+  #*01111111111010110)
 
-;; (deftest substitute-bit-vector.28
-;;   (let* ((orig #*00111001011010110)
-;;          (x (copy-seq orig))
-;;          (result (substitute 0 1 x :key #'1+ :test (complement #'eql))))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*00000000000000000)
+(deftest substitute-bit-vector.28
+  (let* ((orig #*00111001011010110)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x :key #'1+ :test (complement #'eql))))
+    (and (equalp orig x)
+         result))
+  #*00000000000000000)
 
-;; (deftest substitute-bit-vector.29
-;;   (let* ((orig #*00111001011010110)
-;;          (x (copy-seq orig))
-;;          (result (substitute 0 1 x :key #'1+ :test-not #'eql)))
-;;     (and (equalp orig x)
-;;          result))
-;;   #*00000000000000000)
+(deftest substitute-bit-vector.29
+  (let* ((orig #*00111001011010110)
+         (x (copy-seq orig))
+         (result (substitute 0 1 x :key #'1+ :test-not #'eql)))
+    (and (equalp orig x)
+         result))
+  #*00000000000000000)
 
 (deftest substitute-bit-vector.30
-  ;; (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
-  ;;                      :fill-pointer 5 :element-type 'bit))
-  ;;        (result (substitute 1 0 x)))
-  ;;   result)
-    ;; #*11111)
-    (error "problem with making binary array"))
+  (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
+                       :fill-pointer 5 :element-type 'bit))
+         (result (substitute 1 0 x)))
+    result)
+    #*11111)
 
 (deftest substitute-bit-vector.31
-  ;; (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
-  ;;                      :fill-pointer 5 :element-type 'bit))
-  ;;        (result (substitute 1 0 x :from-end t)))
-  ;;   result)
-    ;; #*11111)
-    (error "problem with making binary array"))
+  (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
+                       :fill-pointer 5 :element-type 'bit))
+         (result (substitute 1 0 x :from-end t)))
+    result)
+    #*11111)
 
 (deftest substitute-bit-vector.32
-  ;; (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
-  ;;                      :fill-pointer 5 :element-type 'bit))
-  ;;        (result (substitute 1 0 x :count 1)))
-  ;;   result)
-    ;; #*11011)
-    (error "problem with making binary array"))
+  (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
+                       :fill-pointer 5 :element-type 'bit))
+         (result (substitute 1 0 x :count 1)))
+    result)
+    #*11011)
 
 (deftest substitute-bit-vector.33
-  ;; (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
-  ;;                      :fill-pointer 5 :element-type 'bit))
-  ;;        (result (substitute 1 0 x :from-end t :count 1)))
-  ;;   result)
-    ;; #*01111)
-    (error "problem with making binary array"))
+  (let* ((x (make-array '(10) :initial-contents '(0 1 0 1 1 0 1 1 0 1)
+                       :fill-pointer 5 :element-type 'bit))
+         (result (substitute 1 0 x :from-end t :count 1)))
+    result)
+    #*01111)
 
 ;;; Not so harmless, is it?
 ;; (defharmless substitute.test-and-test-not.1
@@ -1124,16 +1106,14 @@
 
 (def-fold-test substitute.fold.1 (substitute 'z 'b '(a b c)))
 (def-fold-test substitute.fold.2 (substitute 'z 'b #(a b c)))
-;; (def-fold-test substitute.fold.3 (substitute 0 1 #*001101))
-(deftest substitute.fold.3 (error "Look at that ^"))
+(def-fold-test substitute.fold.3 (substitute 0 1 #*001101))
 (def-fold-test substitute.fold.4 (substitute #\a #\b "abcebadfke"))
 
 ;;; Error cases
 
 (deftest substitute.error.1
-;;   (signals-error (substitute) program-error)
-    ;;   t)
-    (error "weird error with signals-error"))
+  (signals-error (substitute) program-error)
+      t)
 
 (deftest substitute.error.2
   (signals-error (substitute 'a) program-error)
@@ -1176,6 +1156,5 @@
   t)
 
 (deftest substitute.error.12
-  ;; (check-type-error #'(lambda (x) (substitute 'a 'b x)) #'sequencep)
-    ;; nil)
-    (error "undefined function check-type-error"))
+  (check-type-error #'(lambda (x) (substitute 'a 'b x)) #'sequencep)
+    nil)


### PR DESCRIPTION
- Move character related functions to `eus-character.l` (still need lots of fixes, though)
- Fix auxiliary functions to pass more tests
- Uncomment bit-vector and other commented tests

With https://github.com/euslisp/ansi-test/pull/32 , https://github.com/euslisp/EusLisp/pull/296 (& https://github.com/furushchev/EusLisp/pull/1) and https://github.com/euslisp/EusLisp/pull/309 I got:
```
ALL RESULTS:                                                                                         
  TEST-NUM: 14639
  PASSED:   6577
  FAILURE:  8062 
```