### PR TITLE
Remove declaims in package tests

### DIFF
--- a/auxiliary/packages00-aux.lsp
+++ b/auxiliary/packages00-aux.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Package test code (common code)
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 (report-and-ignore-errors
   (defpackage "A"

--- a/packages/defpackage.lsp
+++ b/packages/defpackage.lsp
@@ -7,7 +7,7 @@
 
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; defpackage

--- a/packages/delete-package.lsp
+++ b/packages/delete-package.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of DELETE-PACKAGE
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; delete-package
 

--- a/packages/do-external-symbols.lsp
+++ b/packages/do-external-symbols.lsp
@@ -7,7 +7,7 @@
 
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 (defun collect-external-symbols (pkg)
   (remove-duplicates

--- a/packages/do-symbols.lsp
+++ b/packages/do-symbols.lsp
@@ -7,7 +7,7 @@
 
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 (deftest do-symbols.1
   (progn

--- a/packages/export.lsp
+++ b/packages/export.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of EXPORT
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; export

--- a/packages/find-package.lsp
+++ b/packages/find-package.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests for FIND-PACKAGE
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; find-package

--- a/packages/in-package.lsp
+++ b/packages/in-package.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of IN-PACKAGE
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; in-package

--- a/packages/intern.lsp
+++ b/packages/intern.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of INTERN
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; intern

--- a/packages/list-all-packages.lsp
+++ b/packages/list-all-packages.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of LIST-ALL-PACKAGES
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; list-all-packages

--- a/packages/make-package.lsp
+++ b/packages/make-package.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of MAKE-PACKAGE
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; make-package

--- a/packages/package-name.lsp
+++ b/packages/package-name.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of PACKAGE-NAME
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; package-name

--- a/packages/package-nicknames.lsp
+++ b/packages/package-nicknames.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of PACKAGE-NICKNAMES
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; package-nicknames

--- a/packages/rename-package.lsp
+++ b/packages/rename-package.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of RENAME-PACKAGE
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; rename-package

--- a/packages/shadow.lsp
+++ b/packages/shadow.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of SHADOW
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; shadow

--- a/packages/unexport.lsp
+++ b/packages/unexport.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of UNEXPORT
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; unexport

--- a/packages/unintern.lsp
+++ b/packages/unintern.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of UNINTERN
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; unintern

--- a/packages/unuse-package.lsp
+++ b/packages/unuse-package.lsp
@@ -7,7 +7,7 @@
 
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; unuse-package

--- a/packages/use-package.lsp
+++ b/packages/use-package.lsp
@@ -7,7 +7,7 @@
 
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; use-package

--- a/packages/with-package-iterator.lsp
+++ b/packages/with-package-iterator.lsp
@@ -4,7 +4,7 @@
 ;;;; Contains: Tests of WITH-PACKAGE-ITERATOR
 
 
-(declaim (optimize (safety 3)))
+;; (declaim (optimize (safety 3)))
 
 
 


### PR DESCRIPTION
Remove `declaim` from package tests, so we can load the tests even without eus-* auxiliary files.